### PR TITLE
support POST instead of GET for /features/:featureKey/access

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This API does not ship with an authentication layer. You **should not** expose t
 - [`GET` /features/:featureKey](#get-featuresfeaturekey) - Get a single feature flag
 - [`DELETE` /features/:featureKey](#delete-featuresfeaturekey) - Delete a feature flag
 - [`PATCH` /features/:featureKey](#patch-featuresfeaturekey) - Update a feature flag
-- [`GET` /features/:featureKey/access](#get-featuresfeaturekeyaccess) - Check if someone has access to a feature
+- [`POST` /features/:featureKey/access](#get-featuresfeaturekeyaccess) - Check if someone has access to a feature
 
 ### API Documentation
 #### `GET` `/features`
@@ -249,9 +249,9 @@ Update a feature flag.
     Common reason:
     - the percentage must be between `0` and `100`
 
-#### `GET` `/features/:featureKey/access`
+#### `POST` `/features/:featureKey/access`
 Check if a feature flag is enabled for a user or a list of groups.
-- Method: `GET`
+- Method: `POST`
 - Endpoint: `/features/:featureKey/access`
 - Input:
     The `Content-Type` HTTP header should be set to `application/json`

--- a/http/handlers_test.go
+++ b/http/handlers_test.go
@@ -179,21 +179,21 @@ func TestAccessFeatureFlag(t *testing.T) {
 
 	// Access thanks to the user ID
 	reader = strings.NewReader(`{"user":2}`)
-	request, _ := http.NewRequest("GET", fmt.Sprintf("%s/%s/access", base, "homepage_v2"), reader)
+	request, _ := http.NewRequest("POST", fmt.Sprintf("%s/%s/access", base, "homepage_v2"), reader)
 	res, _ := http.DefaultClient.Do(request)
 
 	assertAccessToTheFeature(t, res)
 
 	// No access because of the user ID
 	reader = strings.NewReader(`{"user":3}`)
-	request, _ = http.NewRequest("GET", fmt.Sprintf("%s/%s/access", base, "homepage_v2"), reader)
+	request, _ = http.NewRequest("POST", fmt.Sprintf("%s/%s/access", base, "homepage_v2"), reader)
 	res, _ = http.DefaultClient.Do(request)
 
 	assertNoAccessToTheFeature(t, res)
 
 	// Access thanks to the group
 	reader = strings.NewReader(`{"user":3, "groups":["dev", "foo"]}`)
-	request, _ = http.NewRequest("GET", fmt.Sprintf("%s/%s/access", base, "homepage_v2"), reader)
+	request, _ = http.NewRequest("POST", fmt.Sprintf("%s/%s/access", base, "homepage_v2"), reader)
 	res, _ = http.DefaultClient.Do(request)
 
 	assertAccessToTheFeature(t, res)

--- a/http/routes.go
+++ b/http/routes.go
@@ -45,10 +45,10 @@ func getRoutes(api *APIHandler) Routes {
 			"/features/{featureKey}",
 			api.FeatureShow,
 		},
-		// curl -H "Content-Type: application/json" -d '{"groups":"foo"}' -X GET http://localhost:8080/features/feature_test/access
+		// curl -H "Content-Type: application/json" -X POST -d '{"groups":"foo"}' -X GET http://localhost:8080/features/feature_test/access
 		Route{
 			"FeatureAccess",
-			"GET",
+			"POST",
 			"/features/{featureKey}/access",
 			api.FeatureAccess,
 		},


### PR DESCRIPTION
Hi, nice project! I'm suggesting to change from GET to POST for /features/:featureKey/access. Some clients understand the "convention" to not use request bodies with GET e.g. Postman. See this [discussion](http://stackoverflow.com/questions/978061/http-get-with-request-body) for background.